### PR TITLE
Fix/remove comments and change taunts method

### DIFF
--- a/src/dgplugin.sp
+++ b/src/dgplugin.sp
@@ -39,19 +39,14 @@ public OnPluginStart()
 	HookEvent("teamplay_round_start",Event_RoundStart);
 	RegConsoleCmd("say",Command_Say);
 	RegConsoleCmd("dg_drinklist",DG_DrinkListCommand);
-	// REMOVE Taunt command
-    //RegConsoleCmd("dg_mytaunt",DG_Taunts_MyTauntCommand);
-	//RegConsoleCmd("dg_settaunt",DG_Taunts_SetTauntCommand);
+	RegConsoleCmd("dg_mytaunt",DG_Taunts_MyTauntCommand);
+	RegConsoleCmd("dg_settaunt",DG_Taunts_SetTauntCommand);
 	RegConsoleCmd("dg_info",DG_InfoCommand);
-    // REMOVE Stats command
-    //RegConsoleCmd("dg_stats",DG_StatsCommand);
 	RegConsoleCmd("dg_mystats",DG_Drinks_MyStats);
 	RegAdminCmd("dg_add_bot", DG_AddBotCommand, ADMFLAG_GENERIC);
 	RegAdminCmd("dg_balance", DG_Balance_CallBalanceCommand, ADMFLAG_GENERIC);
 	RegAdminCmd("dg_chuground", DG_Chug_ChugRoundCommand, ADMFLAG_GENERIC);
 
-    // REMOVE Stat URL
-	//dgStatsURL = CreateConVar("dg_statsurl", "http://stats.team-brh.com/dg", "Web location where DGers can view their stats");
 	dgRulesURL = CreateConVar("dg_rulesurl", "http://www.team-brh.com/forums/viewtopic.php?f=8&t=7666", "Web location where rules are posted for when a player types dg_info in chat");
 	dgBottleDeath = CreateConVar("dg_bottledeath", "1", "Spawn bottles based on how many drinks were given on death");
 	dgUnfairBalance = CreateConVar("dg_unfairbalance", "1", "Prevent certain heavy medic pairs from being dg-balanced separated");
@@ -59,10 +54,6 @@ public OnPluginStart()
 	dgDebug = CreateConVar("dg_debug", "0", "Drinking Game Debug Mode");
 	//For findtarget
 	LoadTranslations("common.phrases");
-
-    // REMOVE DG DB Connection
-	// DG_Database_Connect();
-	// DG_Database_LoadWeaponInfo();
 
 	//Turn on holiday mode if month is december
 	new String:date[30];
@@ -148,23 +139,6 @@ public Action:DG_InfoCommand(int client, args) {
 	ShowMOTDPanel(client,"DG Rules",forumPost,MOTDPANEL_TYPE_URL);
 	return Plugin_Handled;
 }
-
-// REMOVE DG Stats command
-/*
-public Action:DG_StatsCommand(int client, args) {
-	new String:text[128];
-	GetCmdArgString(text, sizeof(text));
-	new String:cmd[32];
-	new nextCmd = BreakString(text,cmd,sizeof(cmd));
-	new String:blank[255];
-	if (nextCmd == -1) {
-		ShowDGStats(client, blank);
-	}
-	else {
-		ShowDGStats(client, text[nextCmd]);
-	}
-}
-*/
 
 public Action:DG_DrinkListCommand(int client, args) {
 	DG_ReadList(client,0);
@@ -537,8 +511,6 @@ public DG_GetTopDrinkersString(String:buffer[], size, listmax) {
 	strcopy(buffer,size,rtn);
 }
 
-
-
 public DG_SortByTotalDrinkCount(elem1, elem2, const array[],Handle:hndl) {
 	if (TotalDrinks[elem1] < TotalDrinks[elem2]) {
 		return 1;
@@ -550,28 +522,6 @@ public DG_SortByTotalDrinkCount(elem1, elem2, const array[],Handle:hndl) {
 		return -1;
 	}
 }
-
-// REMOVE Show DG Stats
-/*
-public ShowDGStats(client, String:plrname[]) {
-	new String:statsUrl[300];
-	GetConVarString(dgStatsURL,statsUrl,sizeof(statsUrl));
-
-	new String:steam[32];
-	GetClientAuthId(client,AuthId_Steam2,steam,sizeof(steam));
-	if (strlen(plrname) > 0) {
-		new String: url[255];
-		Format(url,sizeof(url),"%s/dgstats.php?name=%s",statsUrl, plrname);
-		ShowMOTDPanel(client,"DG Stats Search",url, MOTDPANEL_TYPE_URL);
-	}
-	else {
-		new String: url[255];
-		Format(url,sizeof(url),"%s/dgstats.php?steam_id=%s",statsUrl, steam);
-		ShowMOTDPanel(client,"DG Stats player",url, MOTDPANEL_TYPE_URL);
-	}
-}
-*/
-
 
 public Action:DG_AddBotCommand(client, args) {
 	decl String:command[50];

--- a/src/drinks.sp
+++ b/src/drinks.sp
@@ -245,7 +245,7 @@ stock DG_Drinks_GivePlayerDeathDrinks(Handle:event, const String:name[]) {
 		if (atDG) {
 			new attackerWeapon = TF2_GetCurrentWeapon(attacker);
 			new victimWeapon = TF2_GetCurrentWeapon(victim);
-			if (attackerWeapon && victimWeapon) {
+			if (attackerWeapon != -1 && victimWeapon != -1) {
 				new attackerWeaponIndex = GetEntProp(attackerWeapon, Prop_Send, "m_iItemDefinitionIndex");
 				new victimWeaponIndex = GetEntProp(victimWeapon, Prop_Send, "m_iItemDefinitionIndex");
 				if (attackerWeaponIndex == 416 && victimWeaponIndex == 416) { //market gardener weapon index is 416

--- a/src/drinks.sp
+++ b/src/drinks.sp
@@ -71,9 +71,6 @@ stock DG_Drinks_GivePlayerDeathDrinks(Handle:event, const String:name[]) {
 			PrintToChat(victim,"%sDon't get disTRACKted, drink 6",msgColor);	
 			EmitSoundToClient(victim,"vo/burp05.mp3");
 
-			// REMOVE DB Add Drinks
-            //DG_Database_AddDrinks(victim,0,victim,6,0,6,"train");
-
 			new Handle:myPanel = CreatePanel();
 			new String:panelBuffer[100];
 			DrawPanelText(myPanel,"[+6]You got run over by a train");
@@ -120,9 +117,6 @@ stock DG_Drinks_GivePlayerDeathDrinks(Handle:event, const String:name[]) {
 	if (buildingDeath) {
 		BuildingDrinks[victim] += 1;
 		//should this update for dead ringer coward deaths?
-        
-        // REMOVE DB Add Drinks
-		//DG_Database_AddDrinks(atDG ? attacker : 0, asDG ? assister : 0, victim, 1, 1, 1, weaponName);
 
 		PrintToChat(attacker, "%sYou made %s drink %d. Good job!",msgColor, vicName, 1 );
 		if (asDG) {
@@ -391,8 +385,8 @@ stock DG_Drinks_GiveDrinks(victim, drinkCount, attacker, assister, at_drinks, as
 	GetClientAuthId(attacker,AuthId_Steam2,steamID,sizeof(steamID));
 	new String:attaunt[100];
     
-    // REMOVE Get Taunt
-	//DG_Taunts_GetTaunt(steamID,attaunt,sizeof(attaunt),false);
+	//Get custom taunt
+	DG_Taunts_GetTaunt(steamID,attaunt,sizeof(attaunt),false);
 
 	PrintCenterText(victim,"%s DRINK %d BITCH",attaunt, drinkCount);
 	PrintToChat(victim,"%sYou were %s drink %d",msgColor, reason, drinkCount);
@@ -410,8 +404,6 @@ stock DG_Drinks_GiveDrinks(victim, drinkCount, attacker, assister, at_drinks, as
 	}
 	if (GetConVarBool(dgDebug)) {
 		EmitSoundToClient(victim,"vo/burp05.mp3");
-		// REMOVE DB Add Drinks
-		//DG_Database_AddDrinks(atDG ? attacker : 0, asDG ? assister : 0, victim, at_drinks, as_drinks, drinkCount, weaponName);
 	}
 	new Handle:panel = CreatePanel();
 	new String:panelBuffer[100];

--- a/src/globals.sp
+++ b/src/globals.sp
@@ -28,8 +28,6 @@ new String: msgColor[] = "\x04[DG]";
 new dgSprites[MAXPLAYERS + 1];
 new dgSpritesParents[MAXPLAYERS + 1];
 
-// REMOVE DG Stats URL Handle
-// new Handle:dgStatsURL;
 new Handle:dgRulesURL;
 new Handle:dgBottleDeath;
 new Handle:dgUnfairBalance;

--- a/src/taunts.sp
+++ b/src/taunts.sp
@@ -70,6 +70,11 @@ public bool:DG_Taunts_SetTaunt(String:steamID[], String:taunt[]) {
 
 
 public Action:DG_Taunts_SetTauntCommand(int client, args) {
+	//Tell client that the functionality is disabled. Remove these two lines when taunts are good to go again.
+	PrintToChat(client,"%sDG Taunts have been temporarily disabled.",msgColor);
+	return Plugin_Handled;
+
+
 	new String:text[128];
 	GetCmdArgString(text, sizeof(text));
 	if (strlen(text) < 1) {
@@ -90,6 +95,10 @@ public Action:DG_Taunts_SetTauntCommand(int client, args) {
 
 
 public DG_Taunts_GetTaunt(String:steamID[32], String:buf[], bufLen, bool:returnError) {
+	//Taunts are temporarily disabled, so we will return nothing. Remove this line when taunts are good to go.
+	return;
+
+
 	if (StrContains(steamID, "BOT") != -1 ) {
 		return;
 	}
@@ -117,6 +126,11 @@ public DG_Taunts_GetTaunt(String:steamID[32], String:buf[], bufLen, bool:returnE
 }
 
 public Action:DG_Taunts_MyTauntCommand(int client, args) {
+	//Tell client that the functionality is disabled. Remove these two lines when taunts are good to go again.
+	PrintToChat(client,"%sDG Taunts have been temporarily disabled.",msgColor);
+	return Plugin_Handled;
+
+
 	new String:steamID[32];
 	GetClientAuthId(client,AuthId_Steam2,steamID,sizeof(steamID))
 	new String:tag[100];


### PR DESCRIPTION
Merging in changes to master.

- Removed dgStatsURL and corresponding handle.
- Removed methods and calls to DG Stats methods.
- Removed calls to DB methods.
- "dg_settaunt" and "dg_mytaunt" now print a chat message stating that DG Taunts are disabled.
- DG_Taunts_GetTaunt() now returns regardless of inputs. This will ensure that no DB calls are made. All drink taunt message will be the standard "DRINK # BITCH".
- Pulled in updated logic for market gardener jousting drink event.